### PR TITLE
chore: update to v1.1.0

### DIFF
--- a/io.github.finefindus.Hieroglyphic.json
+++ b/io.github.finefindus.Hieroglyphic.json
@@ -1,7 +1,7 @@
 {
     "id": "io.github.finefindus.Hieroglyphic",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "45",
+    "runtime-version": "46",
     "sdk": "org.gnome.Sdk",
     "sdk-extensions": [
         "org.freedesktop.Sdk.Extension.rust-stable"
@@ -25,8 +25,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://github.com/FineFindus/Hieroglyphic/releases/download/v1.0.1/hieroglyphic-1.0.1.tar.xz",
-                    "sha256": "92d02cf646fe5e69cad18d558a40bf6382d8f6ef64fd0067a7123696394c8832"
+                    "url": "https://github.com/FineFindus/Hieroglyphic/releases/download/v1.1.0/hieroglyphic-1.1.0.tar.xz",
+                    "sha256": "bbe440acb464dfa6097e0718a203ed5655d96d3d845588e49c0d04aff9084ca4"
                 }
             ]
         }


### PR DESCRIPTION
Updates to the [v1.1.0 release](https://github.com/FineFindus/Hieroglyphic/releases/tag/v1.1.0)