### PR TITLE
fix: use correct ONNX runtime version and update linking args

### DIFF
--- a/io.github.finefindus.Hieroglyphic.json
+++ b/io.github.finefindus.Hieroglyphic.json
@@ -31,17 +31,17 @@
                     "only-arches": [
                         "x86_64"
                     ],
-                    "sha256": "aa70d48b22e264b82e83f63245b51ddc9a47ae4a3a66903efaff1ba68b7b5930",
+                    "sha256": "b6deea7f2e22c10c043019f294a0ea4d2a6c0ae52a009c34847640db75ec5580",
                     "type": "archive",
-                    "url": "https://github.com/microsoft/onnxruntime/releases/download/v1.20.0/onnxruntime-linux-x64-1.20.0.tgz"
+                    "url": "https://github.com/microsoft/onnxruntime/releases/download/v1.23.0/onnxruntime-linux-x64-1.23.0.tgz"
                 },
                 {
                     "only-arches": [
                         "aarch64"
                     ],
-                    "sha256": "b4d7c6e2c45f8edabe5d28e9bc59ec8d5a4a4af36660cda16e94b2ad85f2a52a",
+                    "sha256": "0b9f47d140411d938e47915824d8daaa424df95a88b5f1fc843172a75168f7a0",
                     "type": "archive",
-                    "url": "https://github.com/microsoft/onnxruntime/releases/download/v1.20.0/onnxruntime-linux-aarch64-1.20.0.tgz"
+                    "url": "https://github.com/microsoft/onnxruntime/releases/download/v1.23.0/onnxruntime-linux-aarch64-1.23.0.tgz"
                 }
             ]
         },

--- a/io.github.finefindus.Hieroglyphic.json
+++ b/io.github.finefindus.Hieroglyphic.json
@@ -17,14 +17,20 @@
         "--env=RUST_BACKTRACE=1"
     ],
     "build-options": {
-        "append-path": "/usr/lib/sdk/rust-stable/bin"
+        "append-path": "/usr/lib/sdk/rust-stable/bin",
+        "env": {
+            "ORT_STRATEGY": "system",
+            "ORT_LIB_LOCATION": "/app/lib/",
+            "RUSTFLAGS": "-L /app/lib"
+        }
     },
     "modules": [
         {
             "name": "onnxruntime",
             "buildsystem": "simple",
             "build-commands": [
-                "cp -r --no-target-directory ./lib /app/lib"
+                "cp -r --no-target-directory lib/ /app/lib/",
+                "cp -r --no-target-directory include/ /app/include/"
             ],
             "sources": [
                 {
@@ -49,12 +55,6 @@
             "name": "hieroglyphic",
             "buildsystem": "meson",
             "run-tests": false,
-            "build-options": {
-                "env": {
-                    "ORT_STRATEGY": "system",
-                    "ORT_LIB_LOCATION": "/app/lib"
-                }
-            },
             "sources": [
                 {
                     "type": "archive",


### PR DESCRIPTION
Fixes an issue, where the application would crash upon drawing a symbol, as the wrong ONNX runtime version was used and incorrectly linked against.